### PR TITLE
Infrastructure: Add Terraform Configuration for AWS Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,17 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Terraform
+*.tfstate
+*.tfstate.*
+*.tfvars
+.terraform/
+.terraform.lock.hcl
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,54 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+  
+  /*
+  backend "s3" {
+    bucket = "mcp-terraform-state"
+    key    = "terraform.tfstate"
+    region = "ap-southeast-2"
+  }
+  */
+}
+
+provider "aws" {
+  region = "ap-southeast-2"
+}
+
+# VPC Module
+module "vpc" {
+  source = "./modules/vpc"
+  
+  vpc_cidr           = "10.0.0.0/16"
+  environment        = "production"
+  project_name       = "mcp"
+  availability_zones = ["ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"]
+  private_subnets    = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets     = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+}
+
+# Security Module
+module "security" {
+  source = "./modules/security"
+  
+  vpc_id       = module.vpc.vpc_id
+  environment  = "production"
+  project_name = "mcp"
+}
+
+# EC2 Module
+module "ec2" {
+  source = "./modules/ec2"
+  
+  vpc_id              = module.vpc.vpc_id
+  public_subnet_ids   = module.vpc.public_subnet_ids
+  security_group_id   = module.security.ec2_security_group_id
+  environment         = "production"
+  project_name        = "mcp"
+  instance_type       = "t3.micro"
+  key_name            = "react-key-pair"
+} 

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -1,0 +1,92 @@
+data "aws_ami" "amazon_linux_2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_instance" "app" {
+  ami           = data.aws_ami.amazon_linux_2.id
+  instance_type = var.instance_type
+
+  subnet_id                   = var.public_subnet_ids[0]
+  vpc_security_group_ids      = [var.security_group_id]
+  associate_public_ip_address = true
+  key_name                   = var.key_name
+
+  root_block_device {
+    volume_size = 20
+    volume_type = "gp3"
+  }
+
+  user_data = base64encode(<<-EOF
+    #!/bin/bash
+    # Update system
+    yum update -y
+    yum install -y gcc-c++ make
+    
+    # Install Node.js 18
+    curl -sL https://rpm.nodesource.com/setup_18.x | bash -
+    yum install -y nodejs
+
+    # Install Nginx
+    amazon-linux-extras install nginx1 -y
+    systemctl start nginx
+    systemctl enable nginx
+
+    # Install Git
+    yum install -y git
+
+    # Clone repository
+    git clone https://github.com/HoangHuyH/mcp.git /var/www/mcp
+    cd /var/www/mcp
+
+    # Install dependencies and build
+    npm install
+    npm run build
+
+    # Configure Nginx
+    cat > /etc/nginx/conf.d/mcp.conf <<'EOL'
+    server {
+        listen 80;
+        server_name _;
+        root /var/www/mcp/dist;
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        location /assets {
+            expires 1y;
+            add_header Cache-Control "public";
+        }
+    }
+    EOL
+
+    # Remove default nginx config
+    rm -f /etc/nginx/conf.d/default.conf
+
+    # Restart Nginx
+    systemctl restart nginx
+
+    # Set up automatic updates
+    yum install -y yum-cron
+    sed -i 's/apply_updates = no/apply_updates = yes/' /etc/yum/yum-cron.conf
+    systemctl start yum-cron
+    systemctl enable yum-cron
+  EOF
+  )
+
+  tags = {
+    Name        = "${var.project_name}-app"
+    Environment = var.environment
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+} 

--- a/terraform/modules/ec2/outputs.tf
+++ b/terraform/modules/ec2/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.app.id
+}
+
+output "public_ip" {
+  description = "Public IP of the EC2 instance"
+  value       = aws_instance.app.public_ip
+}
+
+output "public_dns" {
+  description = "Public DNS of the EC2 instance"
+  value       = aws_instance.app.public_dns
+} 

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -1,0 +1,34 @@
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "IDs of public subnets"
+  type        = list(string)
+}
+
+variable "security_group_id" {
+  description = "ID of the security group"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+}
+
+variable "key_name" {
+  description = "Name of the SSH key pair"
+  type        = string
+} 

--- a/terraform/modules/security/main.tf
+++ b/terraform/modules/security/main.tf
@@ -1,0 +1,50 @@
+resource "aws_security_group" "ec2" {
+  name_prefix = "${var.project_name}-ec2-sg"
+  description = "Security group for EC2 instances"
+  vpc_id      = var.vpc_id
+
+  # Allow inbound HTTP traffic
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTP traffic"
+  }
+
+  # Allow inbound HTTPS traffic
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTPS traffic"
+  }
+
+  # Allow inbound SSH traffic
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow SSH access"
+  }
+
+  # Allow all outbound traffic
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+
+  tags = {
+    Name        = "${var.project_name}-ec2-sg"
+    Environment = var.environment
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+} 

--- a/terraform/modules/security/outputs.tf
+++ b/terraform/modules/security/outputs.tf
@@ -1,0 +1,4 @@
+output "ec2_security_group_id" {
+  description = "ID of the EC2 security group"
+  value       = aws_security_group.ec2.id
+} 

--- a/terraform/modules/security/variables.tf
+++ b/terraform/modules/security/variables.tf
@@ -1,0 +1,14 @@
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+} 

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,70 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${var.project_name}-vpc"
+    Environment = var.environment
+  }
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name        = "${var.project_name}-igw"
+    Environment = var.environment
+  }
+}
+
+# Public Subnets
+resource "aws_subnet" "public" {
+  count             = length(var.public_subnets)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.public_subnets[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "${var.project_name}-public-subnet-${count.index + 1}"
+    Environment = var.environment
+  }
+}
+
+# Private Subnets
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnets)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnets[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name        = "${var.project_name}-private-subnet-${count.index + 1}"
+    Environment = var.environment
+  }
+}
+
+# Route Table for Public Subnets
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name        = "${var.project_name}-public-rt"
+    Environment = var.environment
+  }
+}
+
+# Route Table Association for Public Subnets
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_subnets)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+} 

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = aws_subnet.private[*].id
+} 

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,29 @@
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "Availability zones"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "Private subnet CIDR blocks"
+  type        = list(string)
+}
+
+variable "public_subnets" {
+  description = "Public subnet CIDR blocks"
+  type        = list(string)
+} 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,47 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "prod"
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+  default     = "mcp-blackjack"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "Availability zones"
+  type        = list(string)
+  default     = ["ap-southeast-1a", "ap-southeast-1b"]
+}
+
+variable "private_subnets" {
+  description = "Private subnet CIDR blocks"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "public_subnets" {
+  description = "Public subnet CIDR blocks"
+  type        = list(string)
+  default     = ["10.0.101.0/24", "10.0.102.0/24"]
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "key_name" {
+  description = "Name of the SSH key pair"
+  type        = string
+  default     = "mcp-key"
+} 


### PR DESCRIPTION
## Infrastructure as Code Implementation

This PR adds Terraform configuration for deploying our React application to AWS EC2 in the Asia Pacific (Sydney) region.

### Changes Added:
- VPC configuration with public and private subnets
- Security groups for EC2 instance
- EC2 instance configuration with user data script
- Updated .gitignore for Terraform files

### Infrastructure Components:
1. **VPC Module**
   - CIDR: 10.0.0.0/16
   - 3 public and 3 private subnets across ap-southeast-2 AZs
   - Internet Gateway and route tables

2. **Security Module**
   - Inbound rules for HTTP(80), HTTPS(443), and SSH(22)
   - All outbound traffic allowed

3. **EC2 Module**
   - t3.micro instance type
   - Using react-key-pair for SSH access
   - User data script for application deployment

### Deployment Instructions:
1. Initialize Terraform: `terraform init`
2. Review changes: `terraform plan`
3. Apply changes: `terraform apply`

### Notes:
- AWS credentials need to be configured before applying
- Make sure react-key-pair exists in the AWS account
- Resources will be created in ap-southeast-2 region

### Testing:
- [x] Terraform configuration validates successfully
- [x] Security group rules are appropriate
- [x] VPC CIDR and subnet ranges are correct
- [x] EC2 user data script is properly configured